### PR TITLE
Update how job results are determined, solve IN_PROGRESS issue

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -24057,26 +24057,27 @@ const getWorkflowRunStatus = async () => {
     let lastStep;
     let jobStartDate;
     let abort = false;
-    for (let job of workflowJobs.data.jobs) {
-        for (let step of job.steps) {
+    for (const job of workflowJobs.data.jobs) {
+        for (const step of job.steps) {
             if (step.completed_at !== null) {
                 lastStep = step;
                 jobStartDate = job.started_at;
-                if ((step === null || step === void 0 ? void 0 : step.conclusion) !== "success" && (step === null || step === void 0 ? void 0 : step.conclusion) !== "skipped") {
+                if ((step === null || step === void 0 ? void 0 : step.conclusion) !== `success` && (step === null || step === void 0 ? void 0 : step.conclusion) !== `skipped`) {
                     abort = true;
                     break;
                 }
-                lastStep.conclusion = "success";
+                lastStep.conclusion = `success`;
             }
         }
-        if (abort)
+        if (abort) {
             break;
+        }
     }
     const startTime = (0, moment_1.default)(jobStartDate, moment_1.default.ISO_8601);
     const endTime = (0, moment_1.default)(lastStep === null || lastStep === void 0 ? void 0 : lastStep.completed_at, moment_1.default.ISO_8601);
     return {
-        elapsedSeconds: endTime.diff(startTime, "seconds"),
         conclusion: lastStep === null || lastStep === void 0 ? void 0 : lastStep.conclusion,
+        elapsedSeconds: endTime.diff(startTime, `seconds`),
     };
 };
 exports.getWorkflowRunStatus = getWorkflowRunStatus;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -24057,26 +24057,27 @@ const getWorkflowRunStatus = async () => {
     let lastStep;
     let jobStartDate;
     let abort = false;
-    for (let job of workflowJobs.data.jobs) {
-        for (let step of job.steps) {
+    for (const job of workflowJobs.data.jobs) {
+        for (const step of job.steps) {
             if (step.completed_at !== null) {
                 lastStep = step;
                 jobStartDate = job.started_at;
-                if ((step === null || step === void 0 ? void 0 : step.conclusion) !== "success" && (step === null || step === void 0 ? void 0 : step.conclusion) !== "skipped") {
+                if ((step === null || step === void 0 ? void 0 : step.conclusion) !== `success` && (step === null || step === void 0 ? void 0 : step.conclusion) !== `skipped`) {
                     abort = true;
                     break;
                 }
-                lastStep.conclusion = "success";
+                lastStep.conclusion = `success`;
             }
         }
-        if (abort)
+        if (abort) {
             break;
+        }
     }
     const startTime = (0, moment_1.default)(jobStartDate, moment_1.default.ISO_8601);
     const endTime = (0, moment_1.default)(lastStep === null || lastStep === void 0 ? void 0 : lastStep.completed_at, moment_1.default.ISO_8601);
     return {
-        elapsedSeconds: endTime.diff(startTime, "seconds"),
         conclusion: lastStep === null || lastStep === void 0 ? void 0 : lastStep.conclusion,
+        elapsedSeconds: endTime.diff(startTime, `seconds`),
     };
 };
 exports.getWorkflowRunStatus = getWorkflowRunStatus;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,5 @@
 import { components } from '@octokit/openapi-types';
-import {
-  error,
-  getInput,
-  info,
-  setFailed,
-  setOutput,
-  warning,
-} from '@actions/core';
+import { error, getInput, info, setFailed, setOutput, warning } from '@actions/core';
 import fetch, { Response } from 'node-fetch';
 import moment from 'moment';
 import yaml from 'yaml';
@@ -17,15 +10,14 @@ import { formatCozyLayout } from './layouts/cozy';
 import { formatCompleteLayout } from './layouts/complete';
 import { CustomAction, WorkflowRunStatus } from './types';
 
-export const escapeMarkdownTokens = (text: string) =>
-  text
-    .replace(/\n {1,}/g, `\n `)
-    .replace(/_/g, `\\_`)
-    .replace(/\*/g, `\\*`)
-    .replace(/\|/g, `\\|`)
-    .replace(/#/g, `\\#`)
-    .replace(/-/g, `\\-`)
-    .replace(/>/g, `\\>`);
+export const escapeMarkdownTokens = (text: string) => text
+  .replace(/\n {1,}/g, `\n `)
+  .replace(/_/g, `\\_`)
+  .replace(/\*/g, `\\*`)
+  .replace(/\|/g, `\\|`)
+  .replace(/#/g, `\\#`)
+  .replace(/-/g, `\\-`)
+  .replace(/>/g, `\\>`);
 
 export const getRunInformation = () => {
   const [ owner, repo ] = (process.env.GITHUB_REPOSITORY || ``).split(`/`);
@@ -116,14 +108,11 @@ export const getWorkflowRunStatus = async (): Promise<WorkflowRunStatus> => {
 
   /**
    * https://github.com/patrickpaulin/ms-teams-deploy-card/blob/master/src/utils.ts
-   * We have to verify all jobs steps. We don't know
-   * if users are using multiple jobs or not. Btw,
-   * we don't need to check if GITHUB_JOB env is the
-   * same of the Octokit job name, because it is different.
+   * We have to verify all jobs steps. We don't know if users are using multiple jobs or not.
+   * We don't need to check if GITHUB_JOB env is the same of the Octokit job name, because it is different.
    *
-   * @note We are using a quadratic way to search all steps.
-   * But we have just a few elements, so this is not
-   * a performance issue
+   * @note We are using a quadratic way to search all steps,
+   * but we have just a few elements, so this is not a performance issue
    *
    * The conclusion steps, according to the documentation, are:
    * <success>, <cancelled>, <failure> and <skipped>
@@ -147,9 +136,10 @@ export const getWorkflowRunStatus = async (): Promise<WorkflowRunStatus> => {
         lastStep.conclusion = `success`;
       }
     }
-    // // Some step/job has failed. Get out from here.
+    // Some step/job has failed. Get out from here.
     if (abort) { break; }
   }
+
   const startTime = moment(jobStartDate, moment.ISO_8601);
   const endTime = moment(lastStep?.completed_at, moment.ISO_8601);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { components } from "@octokit/openapi-types";
+import { components } from '@octokit/openapi-types';
 import {
   error,
   getInput,
@@ -6,16 +6,16 @@ import {
   setFailed,
   setOutput,
   warning,
-} from "@actions/core";
-import fetch, { Response } from "node-fetch";
-import moment from "moment";
-import yaml from "yaml";
-import { octokit } from "octokit";
-import { PotentialAction, WebhookBody } from "./models";
-import { formatCompactLayout } from "./layouts/compact";
-import { formatCozyLayout } from "./layouts/cozy";
-import { formatCompleteLayout } from "./layouts/complete";
-import { CustomAction, WorkflowRunStatus } from "./types";
+} from '@actions/core';
+import fetch, { Response } from 'node-fetch';
+import moment from 'moment';
+import yaml from 'yaml';
+import { octokit } from 'octokit';
+import { PotentialAction, WebhookBody } from './models';
+import { formatCompactLayout } from './layouts/compact';
+import { formatCozyLayout } from './layouts/cozy';
+import { formatCompleteLayout } from './layouts/complete';
+import { CustomAction, WorkflowRunStatus } from './types';
 
 export const escapeMarkdownTokens = (text: string) =>
   text
@@ -28,7 +28,7 @@ export const escapeMarkdownTokens = (text: string) =>
     .replace(/>/g, `\\>`);
 
 export const getRunInformation = () => {
-  const [owner, repo] = (process.env.GITHUB_REPOSITORY || ``).split(`/`);
+  const [ owner, repo ] = (process.env.GITHUB_REPOSITORY || ``).split(`/`);
   const branch = process.env.GITHUB_REF?.replace(`refs/heads/`, ``);
   const repoUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`;
   return {
@@ -78,7 +78,7 @@ export const submitNotification = (webhookBody: WebhookBody) => {
 export const formatAndNotify = async (
   state: "start" | "exit",
   conclusion = `in_progress`,
-  elapsedSeconds?: number
+  elapsedSeconds?: number,
 ) => {
   let webhookBody: WebhookBody;
   const { data: commit } = await getOctokitCommit();
@@ -112,7 +112,7 @@ export const getWorkflowRunStatus = async (): Promise<WorkflowRunStatus> => {
   });
 
   let lastStep: components["schemas"]["job"]["steps"][0];
-  let jobStartDate;
+  let jobStartDate: string;
 
   /**
    * https://github.com/patrickpaulin/ms-teams-deploy-card/blob/master/src/utils.ts
@@ -129,14 +129,14 @@ export const getWorkflowRunStatus = async (): Promise<WorkflowRunStatus> => {
    * <success>, <cancelled>, <failure> and <skipped>
    */
   let abort = false;
-  for (let job of workflowJobs.data.jobs) {
-    for (let step of job.steps) {
+  for (const job of workflowJobs.data.jobs) {
+    for (const step of job.steps) {
       // check if current step still running
       if (step.completed_at !== null) {
         lastStep = step;
         jobStartDate = job.started_at;
         // Some step/job has failed. Get out from here.
-        if (step?.conclusion !== "success" && step?.conclusion !== "skipped") {
+        if (step?.conclusion !== `success` && step?.conclusion !== `skipped`) {
           abort = true;
           break;
         }
@@ -144,18 +144,18 @@ export const getWorkflowRunStatus = async (): Promise<WorkflowRunStatus> => {
          * If nothing has failed, so we have a success scenario
          * @note ignoring skipped cases.
          */
-        lastStep.conclusion = "success";
+        lastStep.conclusion = `success`;
       }
     }
     // // Some step/job has failed. Get out from here.
-    if (abort) break;
+    if (abort) { break; }
   }
   const startTime = moment(jobStartDate, moment.ISO_8601);
   const endTime = moment(lastStep?.completed_at, moment.ISO_8601);
 
   return {
-    elapsedSeconds: endTime.diff(startTime, "seconds"),
     conclusion: lastStep?.conclusion,
+    elapsedSeconds: endTime.diff(startTime, `seconds`),
   };
 };
 
@@ -163,12 +163,12 @@ export const renderActions = (statusUrl: string, diffUrl: string) => {
   const actions: PotentialAction[] = [];
   if (getInput(`enable-view-status-action`).toLowerCase() === `true`) {
     actions.push(
-      new PotentialAction(getInput(`view-status-action-text`), [statusUrl])
+      new PotentialAction(getInput(`view-status-action-text`), [ statusUrl ]),
     );
   }
   if (getInput(`enable-review-diffs-action`).toLowerCase() === `true`) {
     actions.push(
-      new PotentialAction(getInput(`review-diffs-action-text`), [diffUrl])
+      new PotentialAction(getInput(`review-diffs-action-text`), [ diffUrl ]),
     );
   }
 
@@ -185,7 +185,7 @@ export const renderActions = (statusUrl: string, diffUrl: string) => {
             action.url !== undefined &&
             action.url.match(/https?:\/\/\S+/g)
           ) {
-            actions.push(new PotentialAction(action.text, [action.url]));
+            actions.push(new PotentialAction(action.text, [ action.url ]));
             customActionsCounter += 1;
           }
         });


### PR DESCRIPTION
Hey 

The issue about the status being always "IN_PROGRESS" was not solvable for me through un-setting job.name in the github actions.

The issue was already solved though by https://github.com/patrickpaulin/ms-teams-deploy-card/tree/master 
Another way of selecting the job result, here is the description by the person creating the solution https://github.com/toko-bifrost/ms-teams-deploy-card/pull/36

I tested the solution in a reusable workflow, so this action is called by another workflow and it is working for failure, cancel, success and skipped.

Your repository is better maintained though and more up to date, so I thought I could add the solution here as in my opinion the solution seems to work absolutely great so far. In my opinion it is crucial for this action to display the correct result of the github action, so I would absolutely recommend to add this.

thank you for the work :) 

Ps: on another note, what the heck is up with your eslintrc.json ?? it was impossible for me to use it, so many strange rules marking everything as an error. Maybe it is also because I use Prettier to format my code, but wow there are a lot of rules in there ^^